### PR TITLE
Helper methods and a RandomPool utility class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 
     <groupId>com.yahoo.bullet</groupId>
     <artifactId>bullet-core</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>bullet-core</name>
 
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/yahoo/bullet-core.git</developerConnection>
-        <tag>bullet-core-0.2.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.yahoo.bullet</groupId>
     <artifactId>bullet-core</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>0.2.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>bullet-core</name>
 

--- a/src/main/java/com/yahoo/bullet/RandomPool.java
+++ b/src/main/java/com/yahoo/bullet/RandomPool.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2016, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
+package com.yahoo.bullet;
+
+import java.util.List;
+import java.util.Random;
+
+public class RandomPool<T> {
+    private List<T> items;
+
+    private static final Random RANDOM = new Random();
+
+    /**
+     * Constructor for the RandomPool that takes a list of items.
+     * @param items A list of items to form the pool with.
+     */
+    public RandomPool(List<T> items) {
+        this.items = items;
+    }
+
+    /**
+     * Get a random item from the pool.
+     *
+     * @return a randomly chosen item from the pool.
+     */
+    public T get() {
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+        return items.get(RANDOM.nextInt(items.size()));
+    }
+
+    /**
+     * Clear the RandomPool. Gets now return null.
+     */
+    public void clear() {
+        items = null;
+    }
+
+    @Override
+    public String toString() {
+        return items == null ? null : items.toString();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null) {
+            return false;
+        }
+        if (!(object instanceof RandomPool)) {
+            return false;
+        }
+        RandomPool asPool = (RandomPool) object;
+        return items == null ? asPool.items == null : items.equals(asPool.items);
+    }
+
+    @Override
+    public int hashCode() {
+        // Any number would do since we want RandomPools of null to be equal to each other.
+        return items == null ? 42 : items.hashCode();
+    }
+}

--- a/src/main/java/com/yahoo/bullet/pubsub/Metadata.java
+++ b/src/main/java/com/yahoo/bullet/pubsub/Metadata.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/yahoo/bullet/pubsub/PubSubException.java
+++ b/src/main/java/com/yahoo/bullet/pubsub/PubSubException.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 /**
@@ -21,5 +26,17 @@ public class PubSubException extends Exception {
      */
     public PubSubException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    /**
+     * Method to create a PubSubException when a required argument could not be read.
+     *
+     * @param name The name of the argument that could not be read.
+     * @param cause The optional {@link Throwable} that caused the exception.
+     * @return A PubSubException indicating failure to read a required argument.
+     */
+    public static PubSubException forArgument(String name, Throwable cause) {
+        String message = "Could not read required argument: " + name;
+        return cause == null ? new PubSubException(message) : new PubSubException(message, cause);
     }
 }

--- a/src/main/java/com/yahoo/bullet/pubsub/PubSubMessage.java
+++ b/src/main/java/com/yahoo/bullet/pubsub/PubSubMessage.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 import com.yahoo.bullet.pubsub.Metadata.Signal;
@@ -13,6 +18,8 @@ import java.util.Objects;
  */
 @Getter
 public class PubSubMessage implements Serializable {
+    private static final long serialVersionUID = 2407848310969237888L;
+
     private String id;
     private int sequence;
     private String content;

--- a/src/main/java/com/yahoo/bullet/pubsub/Publisher.java
+++ b/src/main/java/com/yahoo/bullet/pubsub/Publisher.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 public interface Publisher {

--- a/src/main/java/com/yahoo/bullet/pubsub/Subscriber.java
+++ b/src/main/java/com/yahoo/bullet/pubsub/Subscriber.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 public interface Subscriber {

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -14,6 +14,13 @@
         <property name="severity" value="error"/>
     </module>
 
+    <!--Checks that all files have a copyright header. -->
+    <module name="Header">
+        <property name="headerFile" value="src/main/resources/copyright.txt"/>
+        <property name="ignoreLines" value="2"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
     <!-- Check each Java file for violations. -->
     <module name="TreeWalker">
 

--- a/src/main/resources/copyright.txt
+++ b/src/main/resources/copyright.txt
@@ -1,0 +1,5 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */

--- a/src/test/java/com/yahoo/bullet/RandomPoolTest.java
+++ b/src/test/java/com/yahoo/bullet/RandomPoolTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2016, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
+package com.yahoo.bullet;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class RandomPoolTest {
+    @Test
+    public void testDefaultOverrides() {
+        RandomPool<String> poolA = new RandomPool<>(null);
+        RandomPool<String> poolB = new RandomPool<>(null);
+        Assert.assertTrue(poolA.equals(poolA));
+        Assert.assertEquals(poolA.hashCode(), poolA.hashCode());
+
+        Assert.assertFalse(poolA.equals(null));
+        Assert.assertFalse(poolA.equals("foo"));
+
+        Assert.assertTrue(poolA.equals(poolB));
+        Assert.assertEquals(poolA.hashCode(), poolB.hashCode());
+
+        poolA = new RandomPool<>(Collections.singletonList("foo"));
+        poolB = new RandomPool<>(Collections.singletonList("foo"));
+        Assert.assertTrue(poolA.equals(poolB));
+        Assert.assertEquals(poolA.hashCode(), poolB.hashCode());
+
+        poolB = new RandomPool<>(Collections.singletonList("bar"));
+        Assert.assertFalse(poolA.equals(poolB));
+
+        List<String> contents = Collections.singletonList("foo");
+        poolA = new RandomPool<>(contents);
+        poolB = new RandomPool<>(contents);
+        Assert.assertTrue(poolA.equals(poolB));
+        Assert.assertEquals(poolA.hashCode(), poolB.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        RandomPool<String> pool = new RandomPool<>(null);
+        Assert.assertNull(pool.toString());
+        pool = new RandomPool<>(Collections.singletonList("foo"));
+        Assert.assertEquals(pool.toString(), Collections.singletonList("foo").toString());
+    }
+
+    @Test
+    public void testEmptyCase() {
+        RandomPool<Integer> pool = new RandomPool<>(null);
+        Assert.assertNull(pool.get());
+        pool = new RandomPool<>(Collections.emptyList());
+        Assert.assertNull(pool.get());
+    }
+
+    @Test
+    public void testRandomGet() {
+        List<Integer> list = Arrays.asList(1, 3, 4);
+        Map<Integer, Integer> map = list.stream().collect(Collectors.toMap(Function.identity(), x -> 0));
+        RandomPool<Integer> pool = new RandomPool<>(list);
+        for (int i = 0; i < 1000; ++i) {
+            int item = pool.get();
+            map.put(item, map.get(item) + 1);
+        }
+        // That this is false is 1 - (2/3)^1000
+        Assert.assertTrue(map.values().stream().allMatch(v -> v > 0));
+    }
+
+    @Test
+    public void testGetReturnsNullAfterClear() {
+        List<Integer> list = Arrays.asList(1, 3, 4);
+        RandomPool<Integer> pool = new RandomPool<>(list);
+        pool.clear();
+        Assert.assertNull(pool.get());
+    }
+}

--- a/src/test/java/com/yahoo/bullet/pubsub/MetadataTest.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/MetadataTest.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 import org.testng.Assert;

--- a/src/test/java/com/yahoo/bullet/pubsub/MockPubSub.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/MockPubSub.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 import com.yahoo.bullet.BulletConfig;
@@ -11,7 +16,7 @@ class MockPubSub extends PubSub {
     public static final String MOCK_MESSAGE_NAME = "MOCK_MESSAGE";
     private String mockMessage;
 
-    public MockPubSub(BulletConfig config) {
+    public MockPubSub(BulletConfig config) throws PubSubException {
         super(config);
         mockMessage = config.get(MOCK_MESSAGE_NAME).toString();
     }

--- a/src/test/java/com/yahoo/bullet/pubsub/MockPubSub.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/MockPubSub.java
@@ -18,7 +18,7 @@ class MockPubSub extends PubSub {
 
     public MockPubSub(BulletConfig config) throws PubSubException {
         super(config);
-        mockMessage = config.get(MOCK_MESSAGE_NAME).toString();
+        mockMessage = getRequiredConfig(String.class, MOCK_MESSAGE_NAME);
     }
 
     @Override

--- a/src/test/java/com/yahoo/bullet/pubsub/PubSubExceptionTest.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/PubSubExceptionTest.java
@@ -8,13 +8,26 @@ package com.yahoo.bullet.pubsub;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.UUID;
-
 public class PubSubExceptionTest {
     @Test
     public void testGetMessage() {
-        String randomMessage = UUID.randomUUID().toString();
+        String randomMessage = "foo";
         PubSubException ex = new PubSubException(randomMessage);
         Assert.assertTrue(ex.getMessage().equals(randomMessage));
+    }
+
+    @Test
+    public void testGetArgumentFailedWithoutCause() {
+        PubSubException ex = PubSubException.forArgument("bar", null);
+        Assert.assertEquals(ex.getMessage(), "Could not read required argument: bar");
+        Assert.assertNull(ex.getCause());
+    }
+
+    @Test
+    public void testGetArgumentFailedWithCause() {
+        Throwable cause = new NullPointerException();
+        PubSubException ex = PubSubException.forArgument("bar", cause);
+        Assert.assertEquals(ex.getMessage(), "Could not read required argument: bar");
+        Assert.assertEquals(ex.getCause(), cause);
     }
 }

--- a/src/test/java/com/yahoo/bullet/pubsub/PubSubExceptionTest.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/PubSubExceptionTest.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 import org.testng.Assert;

--- a/src/test/java/com/yahoo/bullet/pubsub/PubSubMessageTest.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/PubSubMessageTest.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 import com.yahoo.bullet.pubsub.Metadata.Signal;

--- a/src/test/java/com/yahoo/bullet/pubsub/PubSubTest.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/PubSubTest.java
@@ -9,6 +9,7 @@ import com.yahoo.bullet.BulletConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.UUID;
 
@@ -44,5 +45,13 @@ public class PubSubTest {
             Assert.assertEquals(e.getCause().getClass(), NullPointerException.class);
             throw e;
         }
+    }
+
+    @Test(expectedExceptions = PubSubException.class)
+    public void testConstructorRuntimeExceptionThrowsPubSubException() throws IOException, PubSubException {
+        BulletConfig config = new BulletConfig("src/test/resources/test_config.yaml");
+        config.set(MockPubSub.MOCK_MESSAGE_NAME, "");
+        config.set(BulletConfig.PUBSUB_CONTEXT_NAME, "");
+        PubSub.from(config);
     }
 }

--- a/src/test/java/com/yahoo/bullet/pubsub/PubSubTest.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/PubSubTest.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 import com.yahoo.bullet.BulletConfig;

--- a/src/test/java/com/yahoo/bullet/pubsub/PublisherTest.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/PublisherTest.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 import org.testng.Assert;

--- a/src/test/java/com/yahoo/bullet/pubsub/SubscriberTest.java
+++ b/src/test/java/com/yahoo/bullet/pubsub/SubscriberTest.java
@@ -1,3 +1,8 @@
+/*
+ *  Copyright 2017, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
 package com.yahoo.bullet.pubsub;
 
 import lombok.NoArgsConstructor;


### PR DESCRIPTION
1) Added helper methods to get configs in PubSub .
2) Added copyright header where missing and a checkstyle for the header.
3) PubSub implementations no longer need to be serializable.
4) PubSub methods throw PubSubException.
5) PubSubMessage assigns serialVersionUID.